### PR TITLE
Glitch - bug fix for let x

### DIFF
--- a/server.js
+++ b/server.js
@@ -101,6 +101,8 @@ const makeIntoCode = (words) => {
   
   let codeLines = words.replace(/ +/g,' ').split('\n');
   
+  variables = []; // reinitialize
+  
   codeLines = codeLines.map(replaceVariableAssignment); // 1) ... equals ... (and ... and ...)
   
   // so other replacements functions can replace string words with recognized variables


### PR DESCRIPTION
```js
x = 1
x = 2
```
should output:
```js
  0  let x = 1;
  1  x = 2;
```
and not this:
```js
  0  let x = 1;
  1  let x = 2;
```